### PR TITLE
Bintray upload simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,31 @@ gradle-mvn-push
 
 See this blog post for more context on this 'library': [http://chris.banes.me/2013/08/27/pushing-aars-to-maven-central/](http://chris.banes.me/2013/08/27/pushing-aars-to-maven-central/).
 
+## Usage with Bintray
+If you already have Maven upload config (if not you see manual below) and want upload library to Bintray you should:
+* Set login data for Bintray for your user to `~/.gradle/gradle.properties`: `BINTRAY_LOGIN` and `BINTRAY_API_KEY`
+* Add `BINTRAY_NAME` to project `gradle.properties`. It's name of project on Bintray. Also this variable is flag "This build should be uploaded to Bintray"
+* apply plugin to build.gradle: `apply from: 'https://raw.github.com/bandlab/gradle-mvn-push/master/gradle-mvn-push.gradle'`
+
+
+###Optional###
+If it's modified version of another library from Maven Central or jCenter you should add `BINTRAY_VERSION_POSTFIX` variable to project `gradle.properties`
+for simple include your modified dependency to your project.
+
+For example:
+
+Original library dependency:
+```compile 'com.rengwuxian.materialedittext:library:2.0.3@aar'```
+
+Modified library dependency with `BINTRAY_VERSION_POSTFIX=without-nineoldandroid`:
+```compile 'com.rengwuxian.materialedittext:library:2.0.3-without-nineoldandroid@aar'```
+
+Also you can replace original library version (for example above it equals `2.0.3`) with variable `BINTRAY_VERSION`
 
 ## Usage
 
 ### 1. Have a working Gradle build
-This is upto you.
+This is up to you.
 
 ### 2. Update your home gradle.properties
 
@@ -61,7 +81,7 @@ POM_PACKAGING=aar
 Add the following at the end of each `build.gradle` that you wish to upload:
 
 ```groovy
-apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
+apply from: 'https://raw.github.com/bandlab/gradle-mvn-push/master/gradle-mvn-push.gradle'
 ```
 
 ### 6. Build and Push

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -23,27 +23,43 @@ def isReleaseBuild() {
     return VERSION_NAME.contains("SNAPSHOT") == false
 }
 
-def getReleaseRepositoryUrl() {
-    def BASE_URL='https://api.bintray.com/content/'
-    def login = hasProperty('BINTRAY_LOGIN')? BINTRAY_LOGIN : "bandlab"
+def getBintrayRepositoryUrl() {
     def version = hasProperty('BINTRAY_VERSION')? BINTRAY_VERSION : VERSION_NAME
-    if (hasProperty('BINTRAY_NAME')) {
-        return "$BASE_URL$login/maven/$BINTRAY_NAME/$version"
+    return "https://api.bintray.com/content/${BINTRAY_LOGIN}/maven/$BINTRAY_NAME/$version"
+}
+
+def getReleaseRepositoryUrl() {
+    if (isBintrayUpload()) {
+        return getBintrayRepositoryUrl()
+    } else {
+        return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+                : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
     }
-    return "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 }
 
 def getSnapshotRepositoryUrl() {
-    return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-            : "https://oss.sonatype.org/content/repositories/snapshots/"
+    if (isBintrayUpload()) {
+        return getBintrayRepositoryUrl()
+    } else {
+        return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+                : "https://oss.sonatype.org/content/repositories/snapshots/"
+    }
 }
 
 def getRepositoryUsername() {
-    return hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
+    return isBintrayUpload() ? BINTRAY_LOGIN : hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : ""
 }
 
 def getRepositoryPassword() {
-    return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+    return isBintrayUpload() ? BINTRAY_API_KEY : hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
+}
+
+def isBintrayUpload() {
+    return hasProperty('BINTRAY_NAME')
+}
+
+def getBintrayVersionPostfix() {
+    return isBintrayUpload() && hasProperty('BINTRAY_VERSION_POSTFIX') ? "-${BINTRAY_VERSION_POSTFIX}" : ""
 }
 
 afterEvaluate { project ->
@@ -54,7 +70,7 @@ afterEvaluate { project ->
 
                 pom.groupId = GROUP
                 pom.artifactId = POM_ARTIFACT_ID
-                pom.version = VERSION_NAME
+                pom.version = VERSION_NAME + getBintrayVersionPostfix()
 
                 repository(url: getReleaseRepositoryUrl()) {
                     authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())


### PR DESCRIPTION
- Bintray auth data now uses own config variables (not NEXUS_*):  BINTRAY_LOGIN and BINTRAY_API_KEY
- New optional parameter BINTRAY_VERSION_POSTFIX. Needs for avoid library version change when you upload modified library to Bintray
- Updated README.md with instructions for Bintray upload